### PR TITLE
Minor setup script fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ rustup toolchain install stable-armv7-unknown-linux-gnueabihf
 With a bela board plugged in and accessible at `bela.local`, run:
 
 ```sh
-./bela_setup_local.sh
+source bela_setup_local.sh
 ```
 
 This downloads the right linker, pulls in some required files from the board,
 and sets up the `$PATH` environment variable. This MUST be called in each
 terminal session that will be used to call `cargo`, but will only download the
-files once.
+files once. The bela board only needs to be plugged in the first time.
 
 # Testing
 

--- a/bela_setup_local.sh
+++ b/bela_setup_local.sh
@@ -15,17 +15,16 @@ then
     curl -o $PACKAGE http://files.bela.io/gcc/$PACKAGE
     unzip $PACKAGE
     rm $PACKAGE
-    echo $'[target.armv7-unknown-linux-gnueabihf]\nlinker =  "arm-bela-linux-gnueabihf-gcc"\n' > .cargo/config
+    echo '[target.armv7-unknown-linux-gnueabihf]\nlinker =  "arm-bela-linux-gnueabihf-gcc"\n' > .cargo/config
   elif [ "$host" = "Linux" ]; then
     PACKAGE="gcc-linaro-6.3.1-2017.02-x86_64_arm-linux-gnueabihf.tar.xz"
     wget https://releases.linaro.org/components/toolchain/binaries/6.3-2017.02/arm-linux-gnueabihf/$PACKAGE
     tar xf $PACKAGE
     mv gcc-linaro-6.3.1-2017.02-x86_64_arm-linux-gnueabihf $DIRECTORY
     rm -r $PACKAGE
-    echo $'[target.armv7-unknown-linux-gnueabihf]\nlinker =  "arm-linux-gnueabihf-gcc"\n' > .cargo/config
+    echo '[target.armv7-unknown-linux-gnueabihf]\nlinker =  "arm-linux-gnueabihf-gcc"\n' > .cargo/config
   fi
 
-  export PATH=$PATH:`pwd`/$DIRECTORY/bin
   scp -r root@$BELA:/root/Bela/include .
   scp -r root@$BELA:/root/Bela/lib .
   scp root@bela.local:/usr/local/lib/libprussdrv.so lib
@@ -37,3 +36,4 @@ then
   scp root@bela.local:/usr/xenomai/lib/libcobalt.so lib
   scp root@bela.local:/lib/arm-linux-gnueabihf/librt.so.1 lib
 fi
+export PATH=$PATH:`pwd`/$DIRECTORY/bin


### PR DESCRIPTION
First of all, thanks a bunch for setting this up, I'm excited to play rusty sounds on my bela!

I had a few issues with the bela_setup_script.sh:
1. The config it put in .cargo/config had a $ at the start which caused cargo to fail immediately.
2. It wouldn't change the PATH since the script was run in a new shell. I changed the README to reflect this, but I don't know if this is the same for all Linux/macOS OSs. You might prefer setting up the environment in a separate script to be sourced? Don't know what's the best practice choice.
3. The PATH wouldn't get set if the `arm-bela-linux-gnueabihf` folder existed so I moved the `export` outside the if statement.

I'm on Ubuntu 20.10. I don't have a macOS machine to test this on though so it would be good if someone with a mac could test!